### PR TITLE
Add script to get emails of editors

### DIFF
--- a/get_editor_emails.py
+++ b/get_editor_emails.py
@@ -1,0 +1,15 @@
+import argparse
+import subprocess
+import shlex
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-p",
+                    help="database password",
+                    type=str)
+args = parser.parse_args()
+
+cmd = "mysql -u metakgp_user --database=metakgp_wiki_db --password=\"{}\" < get_editor_emails.sql >emails.csv".format(args.p)
+
+process = subprocess.Popen('/bin/bash', stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+out, err = process.communicate(cmd.encode('utf-8'))
+print(out.decode('utf-8'))

--- a/get_editor_emails.sql
+++ b/get_editor_emails.sql
@@ -1,0 +1,2 @@
+
+select user_name, user_email from user where user_editcount > 0;


### PR DESCRIPTION
This script needs to be run with the following command
```
mysql -u metakgp_user --database=metakgp_wiki_db --password="password"< get_editor_emails.sql >emails.csv
```
(replace "password" with the actual password)